### PR TITLE
Feature/integrate with float

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,25 @@ Estimatey hooks into the tools that you already use** and provides insights that
 ** provided that they are [Azure DevOps](https://azure.microsoft.com/en-gb/products/devops) and [Float](https://www.float.com/time-tracking/) :stuck_out_tongue_closed_eyes:
 
 ## Limitations
-- When work items are deleted in DevOps this is not reflected in the Estimatey work item cache.
-This is because the work item revisions (annoyingly) doesn't tell us when work items are deleted.
-It does tell use when work items are restored from the recycle bin though!!
-- It keeps the same token for ever so will probably fall over after about 1 hour at the moment...
+- Azure DevOps syncing service keeps the same token for ever so will probably fall over after about 1 hour at the moment...
 
 ## Road Map
+- :construction: Write service to sync logged time from Float.
+    - :construction: Basic implementation fetch all every time.
+    - Persist historic data - after say a month we can assume that logged time won't change or maybe we can read the `locked` parameter.  We need to do this so we aren't fetching an every growing list of time logs and / or hit the 200 per page limit which means we would have to do paginated fetching. Will also need to support syncing historic data for a newly hooked up project with lots of logged time - this could be tricky...
 - Last sync / next sync indicator
 - See if base workItem table would make things easier.
 - See if we can remove DevOpsId and insert id from DevOps into the Id column.
-- Write service to sync time sheets from Float.
 - Basic predictions page
 ![Basic predictions page](./readme-images/basic-predictions-page.png)
 - Normalize work item statuses - take whatever DevOps has and convert to "New", "In progress", "Complete". Configurable mappings.
+- Data quality warnings
+    - If parent is complete but children aren't.
+    - Ticket in progress but no user assigned.
+    - Ticket as been in progress for too long.
+- PR analytics
+    - mean time to complete PRs.
+    - Warning when PR open for too long.
 
 ## Completed features
 - :white_check_mark: Write service to sync work items from DevOps including features, user stories, tasks and their tags.

--- a/estimatey-api/Estimatey.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/estimatey-api/Estimatey.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -5,15 +5,17 @@ namespace Estimatey.Application.Common.Interfaces;
 
 public interface IApplicationDbContext
 {
-    public DbSet<ProjectEntity> Projects { get; }
+    DbSet<ProjectEntity> Projects { get; }
 
-    public DbSet<FeatureEntity> Features { get; }
+    DbSet<FeatureEntity> Features { get; }
 
-    public DbSet<UserStoryEntity> UserStories { get; }
+    DbSet<UserStoryEntity> UserStories { get; }
 
-    public DbSet<TicketEntity> Tickets { get; }
+    DbSet<TicketEntity> Tickets { get; }
 
-    public DbSet<TagEntity> Tags { get; }
+    DbSet<TagEntity> Tags { get; }
 
-    public Task<int> SaveChangesAsync(CancellationToken cancellationToken);
+    DbSet<FloatPersonEntity> FloatPeople { get; }
+
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken);
 }

--- a/estimatey-api/Estimatey.Application/Common/Interfaces/IFloatClient.cs
+++ b/estimatey-api/Estimatey.Application/Common/Interfaces/IFloatClient.cs
@@ -1,0 +1,10 @@
+﻿using Estimatey.Application.Common.Models;
+
+namespace Estimatey.Application.Common.Interfaces;
+
+public interface IFloatClient
+{
+    Task<List<LoggedTimeDto>> GetLoggedTime(int projectId);
+
+    Task<List<FloatPersonDto>> GetPeople();
+}

--- a/estimatey-api/Estimatey.Application/Common/Models/DevOpsFeature.cs
+++ b/estimatey-api/Estimatey.Application/Common/Models/DevOpsFeature.cs
@@ -1,8 +1,0 @@
-﻿namespace Estimatey.Application.Common.Models;
-
-public record DevOpsFeature
-{
-    public int Id { get; init; }
-
-    public required string Title { get; init; }
-}

--- a/estimatey-api/Estimatey.Application/Common/Models/FloatPersonDto.cs
+++ b/estimatey-api/Estimatey.Application/Common/Models/FloatPersonDto.cs
@@ -1,0 +1,11 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Estimatey.Application.Common.Models;
+
+public record FloatPersonDto
+{
+    [JsonPropertyName("people_id")]
+    public int Id { get; init; }
+
+    public string Name { get; init; } = "";
+}

--- a/estimatey-api/Estimatey.Application/Common/Models/LoggedTimeDto.cs
+++ b/estimatey-api/Estimatey.Application/Common/Models/LoggedTimeDto.cs
@@ -1,0 +1,18 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Estimatey.Application.Common.Models;
+
+public record LoggedTimeDto
+{
+    [JsonPropertyName("people_id")]
+    public int PersonId { get; init; }
+
+    public string Date { get; init; } = "";
+
+    public double Hours { get; init; }
+
+    public bool Locked { get; init; }
+
+    [JsonPropertyName("locked_date")]
+    public string LockedDate { get; init; } = "";
+}

--- a/estimatey-api/Estimatey.Application/DeveloperTime/Dtos/DeveloperLoggedTime.cs
+++ b/estimatey-api/Estimatey.Application/DeveloperTime/Dtos/DeveloperLoggedTime.cs
@@ -1,0 +1,23 @@
+﻿using Estimatey.Application.Common.Models;
+using Estimatey.Core.Entities;
+
+namespace Estimatey.Application.DeveloperTime.Dtos;
+
+public record DeveloperLoggedTime
+{
+    public string DeveloperName { get; set; } = "";
+
+    public double TotalLoggedHours { get; set; }
+
+    public static List<DeveloperLoggedTime> MapFromLoggedTime(List<LoggedTimeDto> loggedTime, List<FloatPersonEntity> people)
+    {
+        return loggedTime
+            .GroupBy(_ => _.PersonId)
+            .Select(personTimeGroup => new DeveloperLoggedTime()
+            {
+                DeveloperName = people.FirstOrDefault(_ => _.FloatId == personTimeGroup.Key)?.Name ?? $"Person {personTimeGroup.Key}",
+                TotalLoggedHours = personTimeGroup.Sum(_ => _.Hours)
+            })
+            .ToList();
+    }
+}

--- a/estimatey-api/Estimatey.Application/DeveloperTime/Queries/ListLoggedTimeByDeveloper/ListLoggedTimeByDeveloperQuery.cs
+++ b/estimatey-api/Estimatey.Application/DeveloperTime/Queries/ListLoggedTimeByDeveloper/ListLoggedTimeByDeveloperQuery.cs
@@ -1,0 +1,108 @@
+﻿using Estimatey.Application.Common.AppRequests;
+using Estimatey.Application.Common.Interfaces;
+using Estimatey.Application.Common.Models;
+using Estimatey.Application.DeveloperTime.Dtos;
+using Estimatey.Core.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Estimatey.Application.DeveloperTime.Queries.ListLoggedTimeByDeveloper;
+
+public record ListLoggedTimeByDeveloperQuery
+{
+    public int ProjectId { get; init; }
+}
+
+public class ListLoggedTimeByDeveloperQueryHandler : IRequestHandler<ListLoggedTimeByDeveloperQuery, List<DeveloperLoggedTime>>
+{
+    private readonly IFloatClient _floatClient;
+    private readonly IApplicationDbContext _dbContext;
+    private readonly ILogger _logger;
+
+    private static SemaphoreSlim _syncPeopleSemaphore = new SemaphoreSlim(1, 1);
+
+    public ListLoggedTimeByDeveloperQueryHandler(
+        IFloatClient floatClient,
+        IApplicationDbContext dbContext,
+        ILogger<ListLoggedTimeByDeveloperQueryHandler> logger)
+    {
+        _floatClient = floatClient;
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task<AppResponse<List<DeveloperLoggedTime>>> Handle(
+        ListLoggedTimeByDeveloperQuery query,
+        CancellationToken cancellationToken)
+    {
+        var project = await _dbContext.Projects.FirstOrDefaultAsync(_ => _.Id == query.ProjectId, cancellationToken);
+
+        if (project is null)
+        {
+            return new(404, null, $"No project exists with id {query.ProjectId}.");
+        }
+
+        var allLoggedTime = await _floatClient.GetLoggedTime(project.FloatId);
+        var personIds = allLoggedTime.Select(_ => _.PersonId).Distinct().ToList();
+        var people = await GetPeople(personIds, cancellationToken);
+
+        var developerLoggedTime = DeveloperLoggedTime.MapFromLoggedTime(allLoggedTime, people);
+
+        return new(200, developerLoggedTime);
+    }
+
+    private async Task<List<FloatPersonEntity>> GetPeople(List<int> personIds, CancellationToken cancellationToken)
+    {
+        var existingPeopleFloatIds = await _dbContext.FloatPeople
+            .Select(_ => _.FloatId)
+            .ToListAsync(cancellationToken);
+
+        var missingPeopleCount = personIds.Count(personId => !existingPeopleFloatIds.Contains(personId));
+
+        if (missingPeopleCount != 0)
+        {
+            _logger.LogInformation("Found {missingPeopleCount} people in response from Float which don't exist in database so syncing people.", missingPeopleCount);
+
+            await SyncPeopleWithFloat(cancellationToken);
+        }
+
+        return await _dbContext.FloatPeople
+            .Where(personEntity => personIds.Contains(personEntity.FloatId))
+            .ToListAsync(cancellationToken);
+    }
+
+    private async Task SyncPeopleWithFloat(CancellationToken cancellationToken)
+    {
+        await _syncPeopleSemaphore.WaitAsync();
+
+        try
+        {
+            // Re-fetch inside the lock to make sure we have bang up to date people from db.
+            var existingPeopleFloatIds = await _dbContext.FloatPeople
+                .Select(_ => _.FloatId)
+                .ToListAsync(cancellationToken);
+
+            var peopleFromFloat = await _floatClient.GetPeople();
+
+            foreach (var floatPerson in peopleFromFloat)
+            {
+                if (!existingPeopleFloatIds.Contains(floatPerson.Id))
+                {
+                    _logger.LogInformation("{personName} doesn't exist so adding them.", floatPerson.Name);
+
+                    _dbContext.FloatPeople.Add(new()
+                    {
+                        Name = floatPerson.Name,
+                        FloatId = floatPerson.Id,
+                    });
+                }
+            }
+
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
+        finally
+        {
+            _syncPeopleSemaphore.Release();
+        }
+    }
+}

--- a/estimatey-api/Estimatey.Core/Entities/FloatPersonEntity.cs
+++ b/estimatey-api/Estimatey.Core/Entities/FloatPersonEntity.cs
@@ -1,0 +1,10 @@
+﻿namespace Estimatey.Core.Entities;
+
+public class FloatPersonEntity
+{
+    public int Id { get; set; }
+
+    public int FloatId { get; set; }
+
+    public string Name { get; set; } = "";
+}

--- a/estimatey-api/Estimatey.Core/Entities/ProjectEntity.cs
+++ b/estimatey-api/Estimatey.Core/Entities/ProjectEntity.cs
@@ -6,6 +6,8 @@ public class ProjectEntity
 
     public string DevOpsProjectName { get; set; } = "";
 
+    public int FloatId { get; set; }
+
     public string? WorkItemsContinuationToken { get; set; }
 
     public string? LinksContinuationToken { get; set; }

--- a/estimatey-api/Estimatey.Infrastructure/DependencyInjection.cs
+++ b/estimatey-api/Estimatey.Infrastructure/DependencyInjection.cs
@@ -1,6 +1,7 @@
 using Estimatey.Application.Common.Interfaces;
 using Estimatey.Infrastructure.DateTimes;
 using Estimatey.Infrastructure.DevOps;
+using Estimatey.Infrastructure.Float;
 using Estimatey.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -20,9 +21,16 @@ public static class DependencyInjection
 
         services.AddHostedService<ProjectsSynchronizationService>();
         services.AddHttpClient<DevOpsClient>();
+        services.AddHttpClient<FloatClient>();
+
+        services.AddScoped<IFloatClient>(provider => provider.GetRequiredService<FloatClient>());
 
         services.AddOptions<DevOpsOptions>()
             .Bind(configuration.GetSection("DevOpsOptions"))
+            .ValidateOnStart();
+        
+        services.AddOptions<FloatOptions>()
+            .Bind(configuration.GetSection("FloatOptions"))
             .ValidateOnStart();
 
         return services;

--- a/estimatey-api/Estimatey.Infrastructure/DevOps/DevOpsClient.cs
+++ b/estimatey-api/Estimatey.Infrastructure/DevOps/DevOpsClient.cs
@@ -7,7 +7,6 @@ using System.Net;
 using Azure.Core;
 using Azure.Identity;
 using Microsoft.VisualStudio.Services.Client;
-using System;
 
 internal class DevOpsClient
 {

--- a/estimatey-api/Estimatey.Infrastructure/Float/FloatClient.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Float/FloatClient.cs
@@ -1,0 +1,89 @@
+﻿using Estimatey.Application.Common.Interfaces;
+using Estimatey.Application.Common.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Net.Http.Json;
+
+namespace Estimatey.Infrastructure.Float;
+
+public class FloatClient : IFloatClient
+{
+    private readonly ILogger _logger;
+    private readonly HttpClient _httpClient;
+
+    private readonly string _apiKey;
+    private readonly string _apiBaseUrl;
+
+    public FloatClient(
+        ILogger<FloatClient> logger,
+        HttpClient httpClient,
+        IOptions<FloatOptions> options)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+        _apiKey = options.Value.ApiKey;
+        _apiBaseUrl = options.Value.ApiBaseUri;
+
+        _httpClient.DefaultRequestHeaders.Authorization = new("Bearer", _apiKey);
+    }
+
+    public async Task<List<LoggedTimeDto>> GetLoggedTime(int projectId)
+    {
+        var uri = $"{_apiBaseUrl}/logged-time?project_id={projectId}&per-page=200";
+
+        var response = await _httpClient.GetAsync(uri);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogInformation("Request to get logged time from Float for project {projectId} failed with status code {statusCode}.", projectId, response.StatusCode);
+            throw new Exception($"Request to get logged time from Float for project {projectId} failed with status code {response.StatusCode}.");
+        }
+
+        var loggedTime = await response.Content.ReadFromJsonAsync<List<LoggedTimeDto>>();
+
+        if (loggedTime is null)
+        {
+            _logger.LogWarning("Failed to parse logged time from response from Float.");
+            throw new Exception("Failed to parse logged time from response from Float.");
+        }
+
+        if (loggedTime.Count >= 200)
+        {
+            // Will have to handle multiple pages in future / cache the historic logged time but lets just get something simple up for now.
+            _logger.LogWarning("Probably missing logged time data as the returned page is full.");
+        }
+
+        return loggedTime;
+    }
+
+    public async Task<List<FloatPersonDto>> GetPeople()
+    {
+        var uri = $"{_apiBaseUrl}/people?per-page=200";
+
+        var response = await _httpClient.GetAsync(uri);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogInformation("Request to get people from Float failed with status code {statusCode}.", response.StatusCode);
+            throw new Exception($"Request to get people from Float failed with status code {response.StatusCode}.");
+        }
+
+        var people = await response.Content.ReadFromJsonAsync<List<FloatPersonDto>>();
+
+        if (people is null)
+        {
+            _logger.LogWarning("Failed to parse people from response from Float.");
+            throw new Exception("Failed to parse people from response from Float.");
+        }
+
+        if (people.Count >= 200)
+        {
+            // Unlikely to hit this limit for people but should ideally handle multiple pages.
+            _logger.LogWarning("Probably missing people data as the returned page is full.");
+        }
+
+        _logger.LogDebug("Float returned {peopleCount} people.", people.Count);
+
+        return people;
+    }
+}

--- a/estimatey-api/Estimatey.Infrastructure/Float/FloatOptions.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Float/FloatOptions.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Estimatey.Infrastructure.Float;
+
+public record FloatOptions
+{
+    [Required]
+    public string ApiKey { get; init; } = null!;
+
+    [Required]
+    public string ApiBaseUri { get; init; } = null!;
+}

--- a/estimatey-api/Estimatey.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -17,6 +17,8 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
 
     public DbSet<TagEntity> Tags { get; init; }
 
+    public DbSet<FloatPersonEntity> FloatPeople { get; init; }
+
     public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
         : base(options)
     {

--- a/estimatey-api/Estimatey.Infrastructure/Persistence/EntityConfigurations/FloatPersonEntityTypeConfiguration.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Persistence/EntityConfigurations/FloatPersonEntityTypeConfiguration.cs
@@ -1,0 +1,19 @@
+﻿using Estimatey.Core.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Estimatey.Infrastructure.Persistence.EntityConfigurations;
+
+public class FloatPersonEntityTypeConfiguration : IEntityTypeConfiguration<FloatPersonEntity>
+{
+    public void Configure(EntityTypeBuilder<FloatPersonEntity> builder)
+    {
+        builder.ToTable("FloatPerson");
+
+        builder.Property(_ => _.Id)
+            .HasColumnName("FloatPersonId");
+
+        builder.Property(_ => _.Name)
+            .HasMaxLength(64);
+    }
+}

--- a/estimatey-api/Estimatey.Infrastructure/Persistence/Migrations/20230613200842_AddFloatIdToProjectTable.Designer.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Persistence/Migrations/20230613200842_AddFloatIdToProjectTable.Designer.cs
@@ -4,6 +4,7 @@ using Estimatey.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Estimatey.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230613200842_AddFloatIdToProjectTable")]
+    partial class AddFloatIdToProjectTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -78,28 +81,6 @@ namespace Estimatey.Infrastructure.Persistence.Migrations
                     b.HasIndex("TagId");
 
                     b.ToTable("FeatureTag", (string)null);
-                });
-
-            modelBuilder.Entity("Estimatey.Core.Entities.FloatPersonEntity", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
-                        .HasColumnName("FloatPersonId");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
-
-                    b.Property<int>("FloatId")
-                        .HasColumnType("int");
-
-                    b.Property<string>("Name")
-                        .IsRequired()
-                        .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
-
-                    b.HasKey("Id");
-
-                    b.ToTable("FloatPerson", (string)null);
                 });
 
             modelBuilder.Entity("Estimatey.Core.Entities.ProjectEntity", b =>

--- a/estimatey-api/Estimatey.Infrastructure/Persistence/Migrations/20230613200842_AddFloatIdToProjectTable.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Persistence/Migrations/20230613200842_AddFloatIdToProjectTable.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Estimatey.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFloatIdToProjectTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "FloatId",
+                table: "Project",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FloatId",
+                table: "Project");
+        }
+    }
+}

--- a/estimatey-api/Estimatey.Infrastructure/Persistence/Migrations/20230613211345_AddFloatPersonTable.Designer.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Persistence/Migrations/20230613211345_AddFloatPersonTable.Designer.cs
@@ -4,6 +4,7 @@ using Estimatey.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Estimatey.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230613211345_AddFloatPersonTable")]
+    partial class AddFloatPersonTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/estimatey-api/Estimatey.Infrastructure/Persistence/Migrations/20230613211345_AddFloatPersonTable.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Persistence/Migrations/20230613211345_AddFloatPersonTable.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Estimatey.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFloatPersonTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "FloatPerson",
+                columns: table => new
+                {
+                    FloatPersonId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    FloatId = table.Column<int>(type: "int", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FloatPerson", x => x.FloatPersonId);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "FloatPerson");
+        }
+    }
+}

--- a/estimatey-api/Estimatey.WebApi/Controllers/DeveloperTimeController.cs
+++ b/estimatey-api/Estimatey.WebApi/Controllers/DeveloperTimeController.cs
@@ -1,0 +1,22 @@
+﻿using Estimatey.Application.Common.AppRequests;
+using Estimatey.Application.DeveloperTime.Dtos;
+using Estimatey.Application.DeveloperTime.Queries.ListLoggedTimeByDeveloper;
+using Estimatey.WebApi.Extensions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Estimatey.WebApi.Controllers;
+
+[ApiController]
+public class DeveloperTimeController : ControllerBase
+{
+    [HttpGet("api/projects/{projectId}/logged-time")]
+    public async Task<ActionResult<AppResponse<List<DeveloperLoggedTime>>>> ListLoggedTimeByDeveloper(
+        [FromRoute] int projectId,
+        [FromServices] ListLoggedTimeByDeveloperQueryHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var response = await handler.Handle(new() { ProjectId = projectId }, cancellationToken);
+
+        return response.ToActionResult();
+    }
+}

--- a/estimatey-api/Estimatey.WebApi/appsettings.json
+++ b/estimatey-api/Estimatey.WebApi/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "FloatOptions": {
+    "ApiBaseUri": "https://api.float.com/v3"
+  },
   "AllowedHosts": "*"
 }

--- a/estimatey-api/README.md
+++ b/estimatey-api/README.md
@@ -1,5 +1,8 @@
 # Estimatey Api
 
+### Pre-requisites
+You will need [Azure DevOps](https://azure.microsoft.com/en-gb/products/devops) and [Float](https://www.float.com/time-tracking/) accounts that you have admin access to.
+
 ## Getting started
 First you need to create an app registration in Azure and add make it a project reader in your DevOps project.
 
@@ -10,6 +13,7 @@ Then you need to configure your user secrets in the WebApi project as follows:
   "DevOpsOptions:AzureAadTenantId": "<your Azure tenant id>",
   "DevOpsOptions:ClientId": "<client id of the application registration>",
   "DevOpsOptions:ClientSecret": "<secret created against the application registration>"
+  "FloatOptions:ApiKey": "<Api key from your float account>"
 }
 ```
 


### PR DESCRIPTION
This is a very basic integration to pull logged time from float on demand.  There is a significant limitation in that we don't handle the case where more than 200 results are returned from Float (the max page size).  Ideally we would persist historic data to mitigate the possiblity of ever hitting this limit.  For now I think this PR is a good first step so that we can start to play.

In order to sync name of users from Float I took the following approach:
- When we retrieve logged time from Float, check that we have all the people in our database.
- If not then fetch all people from float and add any that don't yet exist in our database.

This is fairly brute force but people won't be added that often and this approach is simple.