### PR TITLE
Improve float integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Estimatey hooks into the tools that you already use** and provides insights that
 
 ## Limitations
 - Azure DevOps syncing service keeps the same token for ever so will probably fall over after about 1 hour at the moment...
+- On startup we sync historic logged time from float.  Float has restrictions on the size of date range you can request and so at the moment we can only sync up to 1 year of historic data.
 
 ## Road Map
 - :construction: Write service to sync logged time from Float.
@@ -21,7 +22,8 @@ Estimatey hooks into the tools that you already use** and provides insights that
 - Data quality warnings
     - If parent is complete but children aren't.
     - Ticket in progress but no user assigned.
-    - Ticket as been in progress for too long.
+    - Ticket in progress but no branch created.
+    - Ticket has been in progress for too long.
     - Ticket or User Story doesn't have a feature.
     - User not specified as Developer, Designer etc.
 - PR analytics

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Estimatey hooks into the tools that you already use** and provides insights that
     - If parent is complete but children aren't.
     - Ticket in progress but no user assigned.
     - Ticket as been in progress for too long.
+    - Ticket or User Story doesn't have a feature.
+    - User not specified as Developer, Designer etc.
 - PR analytics
     - mean time to complete PRs.
     - Warning when PR open for too long.

--- a/estimatey-api/Estimatey.Application/Common/Configuration/GlobalOptions.cs
+++ b/estimatey-api/Estimatey.Application/Common/Configuration/GlobalOptions.cs
@@ -1,0 +1,6 @@
+﻿namespace Estimatey.Application.Common.Configuration;
+
+public record GlobalOptions
+{
+    public List<int> ExcludedFloatPersonIds { get; set; } = new();
+}

--- a/estimatey-api/Estimatey.Application/Common/Interfaces/IFloatClient.cs
+++ b/estimatey-api/Estimatey.Application/Common/Interfaces/IFloatClient.cs
@@ -4,7 +4,7 @@ namespace Estimatey.Application.Common.Interfaces;
 
 public interface IFloatClient
 {
-    Task<List<LoggedTimeDto>> GetLoggedTime(int projectId);
+    Task<List<LoggedTimeDto>> GetLoggedTime(int projectId, DateOnly? startDate = null, DateOnly? endDate = null);
 
     Task<List<FloatPersonDto>> GetPeople();
 }

--- a/estimatey-api/Estimatey.Application/Common/Interfaces/IFloatClient.cs
+++ b/estimatey-api/Estimatey.Application/Common/Interfaces/IFloatClient.cs
@@ -7,4 +7,6 @@ public interface IFloatClient
     Task<List<LoggedTimeDto>> GetLoggedTime(int projectId, DateOnly? startDate = null, DateOnly? endDate = null);
 
     Task<List<FloatPersonDto>> GetPeople();
+
+    Task SyncPeople();
 }

--- a/estimatey-api/Estimatey.Application/Common/Models/LoggedTimeDto.cs
+++ b/estimatey-api/Estimatey.Application/Common/Models/LoggedTimeDto.cs
@@ -4,6 +4,9 @@ namespace Estimatey.Application.Common.Models;
 
 public record LoggedTimeDto
 {
+    [JsonPropertyName("logged_time_id")]
+    public string Id { get; set; } = "";
+
     [JsonPropertyName("people_id")]
     public int PersonId { get; init; }
 
@@ -14,5 +17,5 @@ public record LoggedTimeDto
     public bool Locked { get; init; }
 
     [JsonPropertyName("locked_date")]
-    public string LockedDate { get; init; } = "";
+    public string? LockedDate { get; init; }
 }

--- a/estimatey-api/Estimatey.Application/DependencyInjection.cs
+++ b/estimatey-api/Estimatey.Application/DependencyInjection.cs
@@ -3,15 +3,21 @@ using Estimatey.Application.Common.AppRequests;
 using FluentValidation;
 using FluentValidation.AspNetCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Estimatey.Application.Common.Configuration;
 
 namespace Estimatey.Application;
 
 public static class DependencyInjection
 {
-    public static IServiceCollection AddApplication(this IServiceCollection services)
+    public static IServiceCollection AddApplication(this IServiceCollection services, IConfiguration configuration)
     {
         AddFluentValidation(services);
         AddRequestHandlers(services);
+
+        services.AddOptions<GlobalOptions>()
+            .Bind(configuration.GetSection("GlobalOptions"))
+            .ValidateOnStart();
 
         return services;
     }

--- a/estimatey-api/Estimatey.Core/Entities/FloatPersonEntity.cs
+++ b/estimatey-api/Estimatey.Core/Entities/FloatPersonEntity.cs
@@ -7,4 +7,6 @@ public class FloatPersonEntity
     public int FloatId { get; set; }
 
     public string Name { get; set; } = "";
+
+    public List<LoggedTimeEntity> LoggedTime { get; set; } = null!;
 }

--- a/estimatey-api/Estimatey.Core/Entities/LoggedTimeEntity.cs
+++ b/estimatey-api/Estimatey.Core/Entities/LoggedTimeEntity.cs
@@ -1,0 +1,21 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Estimatey.Core.Entities;
+
+public class LoggedTimeEntity
+{
+    public int Id { get; init; }
+
+    public string FloatId { get; init; } = "";
+
+    public int FloatPersonId { get; init; }
+    public FloatPersonEntity FloatPerson { get; init; } = null!;
+
+    public DateOnly Date { get; init; }
+
+    public double Hours { get; init; }
+
+    public bool Locked { get; init; }
+
+    public DateOnly? LockedDate { get; init; }
+}

--- a/estimatey-api/Estimatey.Core/Entities/ProjectEntity.cs
+++ b/estimatey-api/Estimatey.Core/Entities/ProjectEntity.cs
@@ -11,4 +11,6 @@ public class ProjectEntity
     public string? WorkItemsContinuationToken { get; set; }
 
     public string? LinksContinuationToken { get; set; }
+
+    public DateOnly? LoggedTimeHasBeenSyncedUntil { get; set; }
 }

--- a/estimatey-api/Estimatey.Infrastructure/DependencyInjection.cs
+++ b/estimatey-api/Estimatey.Infrastructure/DependencyInjection.cs
@@ -19,7 +19,7 @@ public static class DependencyInjection
         services.AddScoped<WorkItemSynchronizationService>();
         services.AddScoped<LinksSynchronizationService>();
 
-        services.AddHostedService<ProjectsSynchronizationService>();
+        //services.AddHostedService<ProjectsSynchronizationService>();
         services.AddHttpClient<DevOpsClient>();
         services.AddHttpClient<FloatClient>();
 

--- a/estimatey-api/Estimatey.Infrastructure/DependencyInjection.cs
+++ b/estimatey-api/Estimatey.Infrastructure/DependencyInjection.cs
@@ -3,6 +3,7 @@ using Estimatey.Infrastructure.DateTimes;
 using Estimatey.Infrastructure.DevOps;
 using Estimatey.Infrastructure.Float;
 using Estimatey.Infrastructure.Persistence;
+using Hangfire;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,6 +19,7 @@ public static class DependencyInjection
         services.AddSingleton<IDateTimeService, DateTimeService>();
         services.AddScoped<WorkItemSynchronizationService>();
         services.AddScoped<LinksSynchronizationService>();
+        services.AddScoped<FloatHistoricLoggedTimeSyncer>();
 
         //services.AddHostedService<ProjectsSynchronizationService>();
         services.AddHttpClient<DevOpsClient>();
@@ -32,6 +34,11 @@ public static class DependencyInjection
         services.AddOptions<FloatOptions>()
             .Bind(configuration.GetSection("FloatOptions"))
             .ValidateOnStart();
+
+        services.AddHangfire(config =>
+            config.UseSqlServerStorage(configuration.GetConnectionString("SqlServer")));
+
+        services.AddHangfireServer();
 
         return services;
     }

--- a/estimatey-api/Estimatey.Infrastructure/DependencyInjection.cs
+++ b/estimatey-api/Estimatey.Infrastructure/DependencyInjection.cs
@@ -21,7 +21,7 @@ public static class DependencyInjection
         services.AddScoped<LinksSynchronizationService>();
         services.AddScoped<FloatHistoricLoggedTimeSyncer>();
 
-        //services.AddHostedService<ProjectsSynchronizationService>();
+        services.AddHostedService<ProjectsSynchronizationService>();
         services.AddHttpClient<DevOpsClient>();
         services.AddHttpClient<FloatClient>();
 

--- a/estimatey-api/Estimatey.Infrastructure/DevOps/DevOpsClient.cs
+++ b/estimatey-api/Estimatey.Infrastructure/DevOps/DevOpsClient.cs
@@ -13,7 +13,7 @@ internal class DevOpsClient
     private readonly ILogger _logger;
     private readonly HttpClient _httpClient;
 
-    private readonly string _azureAadtenantId;
+    private readonly string _azureAadTenantId;
     private readonly string _clientId;
     private readonly string _clientSecret;
     private readonly string _organizationName;
@@ -29,7 +29,7 @@ internal class DevOpsClient
         _httpClient = httpClient;
 
         _organizationName = options.Value.OrganizationName;
-        _azureAadtenantId = options.Value.AzureAadTenantId;
+        _azureAadTenantId = options.Value.AzureAadTenantId;
         _clientId = options.Value.ClientId;
         _clientSecret = options.Value.ClientSecret;
     }
@@ -116,7 +116,7 @@ internal class DevOpsClient
     {
         if (_accessToken is not null) return;
 
-        var credential = new ClientSecretCredential(_azureAadtenantId, _clientId, _clientSecret);
+        var credential = new ClientSecretCredential(_azureAadTenantId, _clientId, _clientSecret);
         var tokenRequestContext = new TokenRequestContext(VssAadSettings.DefaultScopes);
         var accessToken = await credential.GetTokenAsync(tokenRequestContext, CancellationToken.None);
         _accessToken = accessToken.Token;

--- a/estimatey-api/Estimatey.Infrastructure/DevOps/DevOpsClient.cs
+++ b/estimatey-api/Estimatey.Infrastructure/DevOps/DevOpsClient.cs
@@ -119,6 +119,7 @@ internal class DevOpsClient
         var credential = new ClientSecretCredential(_azureAadtenantId, _clientId, _clientSecret);
         var tokenRequestContext = new TokenRequestContext(VssAadSettings.DefaultScopes);
         var accessToken = await credential.GetTokenAsync(tokenRequestContext, CancellationToken.None);
+        _accessToken = accessToken.Token;
 
         _httpClient.DefaultRequestHeaders.Authorization = new("Bearer", accessToken.Token);
     }

--- a/estimatey-api/Estimatey.Infrastructure/DevOps/WorkItemSynchronizationService.cs
+++ b/estimatey-api/Estimatey.Infrastructure/DevOps/WorkItemSynchronizationService.cs
@@ -73,6 +73,7 @@ internal class WorkItemSynchronizationService
                         _logger.LogDebug("Upserting Feature {id}.", workItemRevision.Id);
 
                         var existingFeature = await _dbContext.Features
+                            .IgnoreQueryFilters()
                             .Include(_ => _.Tags)
                             .FirstOrDefaultAsync(_ => _.DevOpsId == workItemRevision.Id);
 
@@ -86,6 +87,7 @@ internal class WorkItemSynchronizationService
                         _logger.LogDebug("Upserting User Story {id}.", workItemRevision.Id);
 
                         var existingUserStory = await _dbContext.UserStories
+                            .IgnoreQueryFilters()
                             .Include(_ => _.Tags)
                             .FirstOrDefaultAsync(_ => _.DevOpsId == workItemRevision.Id);
 
@@ -98,11 +100,12 @@ internal class WorkItemSynchronizationService
                     {
                         _logger.LogDebug("Upserting Ticket {id}.", workItemRevision.Id);
 
-                        var existingUserStory = await _dbContext.Tickets
+                        var existingTicket = await _dbContext.Tickets
+                            .IgnoreQueryFilters()
                             .Include(_ => _.Tags)
                             .FirstOrDefaultAsync(_ => _.DevOpsId == workItemRevision.Id);
 
-                        await UpsertWorkItem(project.Id, existingUserStory, workItemRevision);
+                        await UpsertWorkItem(project.Id, existingTicket, workItemRevision);
 
                         break;
                     }

--- a/estimatey-api/Estimatey.Infrastructure/Estimatey.Infrastructure.csproj
+++ b/estimatey-api/Estimatey.Infrastructure/Estimatey.Infrastructure.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.9.0" />
+    <PackageReference Include="Hangfire" Version="1.8.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.2" />
 	  <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.219.0-preview" />
 	  <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="19.219.0-preview" />

--- a/estimatey-api/Estimatey.Infrastructure/Float/FloatClient_People.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Float/FloatClient_People.cs
@@ -1,0 +1,78 @@
+﻿using Estimatey.Application.Common.Interfaces;
+using Estimatey.Application.Common.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System.Net.Http.Json;
+using System.Threading;
+
+namespace Estimatey.Infrastructure.Float;
+
+public partial class FloatClient : IFloatClient
+{
+    private static SemaphoreSlim _syncPeopleSemaphore = new SemaphoreSlim(1, 1);
+
+    public async Task<List<FloatPersonDto>> GetPeople()
+    {
+        var uri = $"{_apiBaseUrl}/people?per-page=200";
+
+        var response = await _httpClient.GetAsync(uri);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogInformation("Request to get people from Float failed with status code {statusCode}.", response.StatusCode);
+            throw new Exception($"Request to get people from Float failed with status code {response.StatusCode}.");
+        }
+
+        var people = await response.Content.ReadFromJsonAsync<List<FloatPersonDto>>();
+
+        if (people is null)
+        {
+            _logger.LogWarning("Failed to parse people from response from Float.");
+            throw new Exception("Failed to parse people from response from Float.");
+        }
+
+        if (people.Count >= 200)
+        {
+            // Unlikely to hit this limit for people but should ideally handle multiple pages.
+            _logger.LogWarning("Probably missing people data as the returned page is full.");
+        }
+
+        _logger.LogDebug("Float returned {peopleCount} people.", people.Count);
+
+        return people;
+    }
+
+    public async Task SyncPeople()
+    {
+        await _syncPeopleSemaphore.WaitAsync();
+
+        try
+        {
+            var existingPeopleFloatIds = await _dbContext.FloatPeople
+            .Select(_ => _.FloatId)
+                .ToListAsync();
+
+            var peopleFromFloat = await GetPeople();
+
+            foreach (var floatPerson in peopleFromFloat)
+            {
+                if (!existingPeopleFloatIds.Contains(floatPerson.Id))
+                {
+                    _logger.LogInformation("{personName} doesn't exist so adding them.", floatPerson.Name);
+
+                    _dbContext.FloatPeople.Add(new()
+                    {
+                        Name = floatPerson.Name,
+                        FloatId = floatPerson.Id,
+                    });
+                }
+            }
+
+            await _dbContext.SaveChangesAsync();
+        }
+        finally
+        {
+            _syncPeopleSemaphore.Release();
+        }
+    }
+}

--- a/estimatey-api/Estimatey.Infrastructure/Float/FloatHistoricLoggedTimeSyncer.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Float/FloatHistoricLoggedTimeSyncer.cs
@@ -1,0 +1,87 @@
+﻿using Estimatey.Application.Common.Interfaces;
+using Estimatey.Core.Entities;
+using Estimatey.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.Services.Common;
+
+namespace Estimatey.Infrastructure.Float;
+
+public class FloatHistoricLoggedTimeSyncer
+{
+    private readonly ApplicationDbContext _dbContext;
+    private readonly ILogger _logger;
+    private readonly IDateTimeService _dateTimeService;
+    private readonly IFloatClient _floatClient;
+
+    private readonly int _persistLoggedTimeBeforeDaysAgo;
+
+    public FloatHistoricLoggedTimeSyncer(
+        IOptions<FloatOptions> options,
+        ApplicationDbContext dbContext,
+        ILogger<FloatHistoricLoggedTimeSyncer> logger,
+        IDateTimeService dateTimeService,
+        IFloatClient floatClient)
+    {
+        _dbContext = dbContext;
+
+        _persistLoggedTimeBeforeDaysAgo = options.Value.PersistLoggedTimeBeforeDaysAgo;
+        _logger = logger;
+        _dateTimeService = dateTimeService;
+        _floatClient = floatClient;
+    }
+
+    public async Task SyncHistoricLoggedTime()
+    {
+        var projects = await _dbContext.Projects.ToListAsync();
+        var people = await _dbContext.FloatPeople.ToListAsync();
+
+        // TODO: sync float people like we do in ListDeveloperLoggedTimeQueryHandler.
+
+        _logger.LogInformation("Syncing historic logged time for {projectsCount} projects.", projects.Count);
+
+        foreach (var project in projects)
+        {
+            await SyncProject(project, people);
+        }
+    }
+
+    private async Task SyncProject(ProjectEntity project, List<FloatPersonEntity> people)
+    {
+        DateOnly? syncLoggedTimeFrom = project.LoggedTimeHasBeenSyncedUntil.HasValue ?
+            project.LoggedTimeHasBeenSyncedUntil.Value.AddDays(1) :
+            null;
+
+        var syncLoggedTimeUntil = DateOnly.FromDateTime(_dateTimeService.Now.AddDays(-_persistLoggedTimeBeforeDaysAgo - 1));
+
+        _logger.LogDebug("Syncing historic logged time for project {projectId} between {startDate} and {endDate}.", project.Id, syncLoggedTimeFrom, syncLoggedTimeUntil);
+
+        if (project.LoggedTimeHasBeenSyncedUntil is not null &&
+            project.LoggedTimeHasBeenSyncedUntil >= syncLoggedTimeUntil)
+        {
+            return;
+        }
+
+        var historicLoggedTime = await _floatClient.GetLoggedTime(project.FloatId, syncLoggedTimeFrom, syncLoggedTimeUntil);
+
+        var loggedTimeEntities = historicLoggedTime.Select(_ => new LoggedTimeEntity
+        {
+            FloatId = _.Id,
+            FloatPersonId = people.First(person => person.FloatId == _.PersonId).Id,
+            Date = DateOnly.Parse(_.Date),
+            Hours = _.Hours,
+            Locked = _.Locked,
+            LockedDate = _.LockedDate is null ? null : DateOnly.Parse(_.LockedDate),
+        });
+
+        _logger.LogDebug("Persisting {loggedTimeEntriesCount} logged time entries.", loggedTimeEntities.Count());
+
+        project.LoggedTimeHasBeenSyncedUntil = syncLoggedTimeUntil;
+
+        _dbContext.LoggedTime.AddRange(loggedTimeEntities);
+        await _dbContext.SaveChangesAsync();
+
+        _logger.LogDebug("Successfully synced historic logged time for project {projectId} between {startDate} and {endDate}.", project.Id, syncLoggedTimeFrom, syncLoggedTimeUntil);
+    }
+}

--- a/estimatey-api/Estimatey.Infrastructure/Float/FloatHistoricLoggedTimeSyncer.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Float/FloatHistoricLoggedTimeSyncer.cs
@@ -57,9 +57,10 @@ public class FloatHistoricLoggedTimeSyncer
 
         _logger.LogDebug("Syncing historic logged time for project {projectId} between {startDate} and {endDate}.", project.Id, syncLoggedTimeFrom, syncLoggedTimeUntil);
 
-        if (project.LoggedTimeHasBeenSyncedUntil is not null &&
-            project.LoggedTimeHasBeenSyncedUntil >= syncLoggedTimeUntil)
+        if (syncLoggedTimeFrom is not null &&
+            syncLoggedTimeFrom >= syncLoggedTimeUntil)
         {
+            _logger.LogInformation("Historic logged time is up to date so no need to sync.");
             return;
         }
 

--- a/estimatey-api/Estimatey.Infrastructure/Float/FloatHistoricLoggedTimeSyncer.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Float/FloatHistoricLoggedTimeSyncer.cs
@@ -4,7 +4,6 @@ using Estimatey.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.VisualStudio.Services.Common;
 
 namespace Estimatey.Infrastructure.Float;
 
@@ -49,20 +48,20 @@ public class FloatHistoricLoggedTimeSyncer
 
     private async Task SyncProject(ProjectEntity project, List<FloatPersonEntity> people)
     {
-        DateOnly? syncLoggedTimeFrom = project.LoggedTimeHasBeenSyncedUntil.HasValue ?
-            project.LoggedTimeHasBeenSyncedUntil.Value.AddDays(1) :
-            null;
-
         var syncLoggedTimeUntil = DateOnly.FromDateTime(_dateTimeService.Now.AddDays(-_persistLoggedTimeBeforeDaysAgo - 1));
 
-        _logger.LogDebug("Syncing historic logged time for project {projectId} between {startDate} and {endDate}.", project.Id, syncLoggedTimeFrom, syncLoggedTimeUntil);
-
-        if (syncLoggedTimeFrom is not null &&
-            syncLoggedTimeFrom >= syncLoggedTimeUntil)
+        if (project.LoggedTimeHasBeenSyncedUntil is not null &&
+            project.LoggedTimeHasBeenSyncedUntil >= syncLoggedTimeUntil)
         {
             _logger.LogInformation("Historic logged time is up to date so no need to sync.");
             return;
         }
+
+        DateOnly? syncLoggedTimeFrom = project.LoggedTimeHasBeenSyncedUntil.HasValue ?
+            project.LoggedTimeHasBeenSyncedUntil.Value.AddDays(1) :
+            null;
+
+        _logger.LogDebug("Syncing historic logged time for project {projectId} between {startDate} and {endDate}.", project.Id, syncLoggedTimeFrom, syncLoggedTimeUntil);
 
         var historicLoggedTime = await _floatClient.GetLoggedTime(project.FloatId, syncLoggedTimeFrom, syncLoggedTimeUntil);
 

--- a/estimatey-api/Estimatey.Infrastructure/Float/FloatOptions.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Float/FloatOptions.cs
@@ -9,4 +9,7 @@ public record FloatOptions
 
     [Required]
     public string ApiBaseUri { get; init; } = null!;
+
+    [Required]
+    public int PersistLoggedTimeBeforeDaysAgo { get; init; }
 }

--- a/estimatey-api/Estimatey.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -1,5 +1,6 @@
 using Estimatey.Application.Common.Interfaces;
 using Estimatey.Core.Entities;
+using Estimatey.Infrastructure.Persistence.ValueConverters;
 using Microsoft.EntityFrameworkCore;
 using System.Reflection;
 
@@ -18,6 +19,8 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
     public DbSet<TagEntity> Tags { get; init; }
 
     public DbSet<FloatPersonEntity> FloatPeople { get; init; }
+
+    public DbSet<LoggedTimeEntity> LoggedTime { get; init; }
 
     public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
         : base(options)
@@ -39,5 +42,18 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
             .HasQueryFilter(_ => !_.IsDeleted);
 
         base.OnModelCreating(modelBuilder);
+    }
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder builder)
+    {
+        base.ConfigureConventions(builder);
+
+        builder.Properties<DateOnly>()
+            .HaveConversion<DateOnlyConverter>()
+            .HaveColumnType("date");
+
+        builder.Properties<DateTime>()
+            .HaveConversion<DateTimeConverter>()
+            .HaveColumnType("datetime2");
     }
 }

--- a/estimatey-api/Estimatey.Infrastructure/Persistence/EntityConfigurations/FloatPersonEntityTypeConfiguration.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Persistence/EntityConfigurations/FloatPersonEntityTypeConfiguration.cs
@@ -13,6 +13,9 @@ public class FloatPersonEntityTypeConfiguration : IEntityTypeConfiguration<Float
         builder.Property(_ => _.Id)
             .HasColumnName("FloatPersonId");
 
+        builder.HasIndex(_ => _.FloatId)
+            .IsUnique();
+
         builder.Property(_ => _.Name)
             .HasMaxLength(64);
     }

--- a/estimatey-api/Estimatey.Infrastructure/Persistence/EntityConfigurations/LoggedTimeEntityTypeConfiguration.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Persistence/EntityConfigurations/LoggedTimeEntityTypeConfiguration.cs
@@ -12,5 +12,11 @@ public class LoggedTimeEntityTypeConfiguration : IEntityTypeConfiguration<Logged
 
         builder.Property(_ => _.Id)
             .HasColumnName("LoggedTimeId");
+
+        builder.HasIndex(_ => _.FloatId)
+            .IsUnique();
+
+        builder.Property(_ => _.FloatId)
+            .HasMaxLength(24);
     }
 }

--- a/estimatey-api/Estimatey.Infrastructure/Persistence/EntityConfigurations/LoggedTimeEntityTypeConfiguration.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Persistence/EntityConfigurations/LoggedTimeEntityTypeConfiguration.cs
@@ -1,0 +1,16 @@
+﻿using Estimatey.Core.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Estimatey.Infrastructure.Persistence.EntityConfigurations;
+
+public class LoggedTimeEntityTypeConfiguration : IEntityTypeConfiguration<LoggedTimeEntity>
+{
+    public void Configure(EntityTypeBuilder<LoggedTimeEntity> builder)
+    {
+        builder.ToTable("LoggedTime");
+
+        builder.Property(_ => _.Id)
+            .HasColumnName("LoggedTimeId");
+    }
+}

--- a/estimatey-api/Estimatey.Infrastructure/Persistence/Migrations/20230615221455_AddLoggedTime.Designer.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Persistence/Migrations/20230615221455_AddLoggedTime.Designer.cs
@@ -4,6 +4,7 @@ using Estimatey.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Estimatey.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230615221455_AddLoggedTime")]
+    partial class AddLoggedTime
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/estimatey-api/Estimatey.Infrastructure/Persistence/Migrations/20230615221455_AddLoggedTime.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Persistence/Migrations/20230615221455_AddLoggedTime.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Estimatey.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLoggedTime : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LoggedTimeHasBeenSyncedUntil",
+                table: "Project",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "LoggedTime",
+                columns: table => new
+                {
+                    LoggedTimeId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    FloatId = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    FloatPersonId = table.Column<int>(type: "int", nullable: false),
+                    Date = table.Column<DateTime>(type: "date", nullable: false),
+                    Hours = table.Column<double>(type: "float", nullable: false),
+                    Locked = table.Column<bool>(type: "bit", nullable: false),
+                    LockedDate = table.Column<DateTime>(type: "date", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LoggedTime", x => x.LoggedTimeId);
+                    table.ForeignKey(
+                        name: "FK_LoggedTime_FloatPerson_FloatPersonId",
+                        column: x => x.FloatPersonId,
+                        principalTable: "FloatPerson",
+                        principalColumn: "FloatPersonId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LoggedTime_FloatPersonId",
+                table: "LoggedTime",
+                column: "FloatPersonId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LoggedTime");
+
+            migrationBuilder.DropColumn(
+                name: "LoggedTimeHasBeenSyncedUntil",
+                table: "Project");
+        }
+    }
+}

--- a/estimatey-api/Estimatey.Infrastructure/Persistence/Migrations/20230619201121_AddUniqueConstraintsOnFloatIds.Designer.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Persistence/Migrations/20230619201121_AddUniqueConstraintsOnFloatIds.Designer.cs
@@ -4,6 +4,7 @@ using Estimatey.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Estimatey.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230619201121_AddUniqueConstraintsOnFloatIds")]
+    partial class AddUniqueConstraintsOnFloatIds
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/estimatey-api/Estimatey.Infrastructure/Persistence/Migrations/20230619201121_AddUniqueConstraintsOnFloatIds.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Persistence/Migrations/20230619201121_AddUniqueConstraintsOnFloatIds.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Estimatey.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUniqueConstraintsOnFloatIds : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "FloatId",
+                table: "LoggedTime",
+                type: "nvarchar(24)",
+                maxLength: 24,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LoggedTime_FloatId",
+                table: "LoggedTime",
+                column: "FloatId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FloatPerson_FloatId",
+                table: "FloatPerson",
+                column: "FloatId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_LoggedTime_FloatId",
+                table: "LoggedTime");
+
+            migrationBuilder.DropIndex(
+                name: "IX_FloatPerson_FloatId",
+                table: "FloatPerson");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FloatId",
+                table: "LoggedTime",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(24)",
+                oldMaxLength: 24);
+        }
+    }
+}

--- a/estimatey-api/Estimatey.Infrastructure/Persistence/ValueConverters/DateOnlyValueConverter.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Persistence/ValueConverters/DateOnlyValueConverter.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Estimatey.Infrastructure.Persistence.ValueConverters;
+
+public class DateOnlyConverter : ValueConverter<DateOnly, DateTime>
+{
+    public DateOnlyConverter() : base(
+            dateOnly => dateOnly.ToDateTime(TimeOnly.MinValue),
+            dateTime => DateOnly.FromDateTime(dateTime))
+    {
+    }
+}

--- a/estimatey-api/Estimatey.Infrastructure/Persistence/ValueConverters/DateTimeConverter.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Persistence/ValueConverters/DateTimeConverter.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Estimatey.Infrastructure.Persistence.ValueConverters;
+
+internal class DateTimeConverter : ValueConverter<DateTime, DateTime>
+{
+    public DateTimeConverter() : base(
+            dateTime => dateTime.ToUniversalTime(),
+            dateTime => DateTime.SpecifyKind(dateTime, DateTimeKind.Utc))
+    {
+    }
+}

--- a/estimatey-api/Estimatey.WebApi/Estimatey.WebApi.csproj
+++ b/estimatey-api/Estimatey.WebApi/Estimatey.WebApi.csproj
@@ -8,6 +8,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Hangfire" Version="1.8.2" />
+		<PackageReference Include="Hangfire.Dashboard.BasicAuthorization" Version="1.0.2" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.1" />
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />

--- a/estimatey-api/Estimatey.WebApi/Program.cs
+++ b/estimatey-api/Estimatey.WebApi/Program.cs
@@ -1,9 +1,13 @@
 using Estimatey.Application;
 using Estimatey.Infrastructure;
+using Estimatey.Infrastructure.Float;
+using Hangfire;
+using Hangfire.Dashboard.BasicAuthorization;
 
 var builder = WebApplication.CreateBuilder(args);
 
 var services = builder.Services;
+var configuration = builder.Configuration;
 
 #region addServices
 
@@ -18,8 +22,8 @@ services.AddControllers();
 services.AddHttpClient();
 services.AddHttpContextAccessor();
 
-services.AddApplication(builder.Configuration);
-services.AddInfrastructure(builder.Configuration);
+services.AddApplication(configuration);
+services.AddInfrastructure(configuration);
 
 services.AddEndpointsApiExplorer();
 services.AddSwaggerGen();
@@ -35,6 +39,48 @@ if (app.Environment.IsDevelopment())
     app.UseSwagger();
     app.UseSwaggerUI();
 }
+
+var hangfireLogin = configuration
+    .GetSection("HangfireCredentials")
+    .GetValue<string>("Username");
+
+var hangfirePassword = configuration
+    .GetSection("HangfireCredentials")
+    .GetValue<string>("Password");
+
+app.UseHangfireDashboard(options: new()
+{
+    Authorization = new[]
+    {
+        new BasicAuthAuthorizationFilter(new()
+        {
+            LoginCaseSensitive = true,
+            Users = new[]
+            {
+                new BasicAuthAuthorizationUser
+                {
+                    Login = hangfireLogin,
+                    PasswordClear = hangfirePassword,
+                }
+            }
+        })
+    },
+    AppPath = "/swagger",
+    DashboardTitle = "Estimatey"
+});
+
+RecurringJob.AddOrUpdate(
+    "Reports Snapshot",
+    () => app.Services.CreateScope()
+        .ServiceProvider.GetRequiredService<FloatHistoricLoggedTimeSyncer>()
+        .SyncHistoricLoggedTime(),
+    Cron.Daily);
+
+// Run once on startup
+BackgroundJob.Enqueue(
+    () => app.Services.CreateScope()
+        .ServiceProvider.GetRequiredService<FloatHistoricLoggedTimeSyncer>()
+        .SyncHistoricLoggedTime());
 
 app.UseHttpsRedirection();
 

--- a/estimatey-api/Estimatey.WebApi/Program.cs
+++ b/estimatey-api/Estimatey.WebApi/Program.cs
@@ -18,7 +18,7 @@ services.AddControllers();
 services.AddHttpClient();
 services.AddHttpContextAccessor();
 
-services.AddApplication();
+services.AddApplication(builder.Configuration);
 services.AddInfrastructure(builder.Configuration);
 
 services.AddEndpointsApiExplorer();

--- a/estimatey-api/Estimatey.WebApi/appsettings.Development.json
+++ b/estimatey-api/Estimatey.WebApi/appsettings.Development.json
@@ -7,5 +7,9 @@
   },
   "ConnectionStrings": {
     "SqlServer": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EstimateyWebApi;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False"
+  },
+  "HangfireCredentials": {
+    "Username": "FirstMate",
+    "Password": "Estim80!"
   }
 }

--- a/estimatey-api/Estimatey.WebApi/appsettings.json
+++ b/estimatey-api/Estimatey.WebApi/appsettings.json
@@ -6,7 +6,8 @@
     }
   },
   "FloatOptions": {
-    "ApiBaseUri": "https://api.float.com/v3"
+    "ApiBaseUri": "https://api.float.com/v3",
+    "PersistLoggedTimeBeforeDaysAgo": 50
   },
   "AllowedHosts": "*"
 }

--- a/estimatey-api/README.md
+++ b/estimatey-api/README.md
@@ -17,6 +17,16 @@ Then you need to configure your user secrets in the WebApi project as follows:
 }
 ```
 
+Optionally you can specify Float people to ignore e.g. if you only want to account for developers. This is done by adding the following to your user secrets:
+```JSON
+{
+  "FloatOptions:PeopleToIgnore": [
+	"<float person id 1>"
+	...
+  ]
+}
+```
+
 Then you need to migrate the database by running the following command in the estimatey-api folder:
 ```
 dotnet ef database update --project .\Estimatey.Infrastructure\ --startup-project .\Estimatey.WebApi\


### PR DESCRIPTION
- Handle cases where float returns more than 1 page of logged time results.
- Allow ignoring people from float - so we can just account for developer time as that is what we need to crrelate to DevOps tickets.
- Syncs "historic" logged time from Float and persists them in the Estimatey DB.  Does this by running a daily batch job (using Hangfire) that fetches work from before 50 days ago and after the last successful sync date.
- Also fix bug which was causing crash when syncing deleted work items from DevOps.