### PR TITLE
Finish float integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@ Estimatey hooks into the tools that you already use** and provides insights that
 - On startup we sync historic logged time from float.  Float has restrictions on the size of date range you can request and so at the moment we can only sync up to 1 year of historic data.
 
 ## Road Map
-- :construction: Write service to sync logged time from Float.
-    - :construction: Basic implementation fetch all every time.
-    - Persist historic data - after say a month we can assume that logged time won't change or maybe we can read the `locked` parameter.  We need to do this so we aren't fetching an every growing list of time logs and / or hit the 200 per page limit which means we would have to do paginated fetching. Will also need to support syncing historic data for a newly hooked up project with lots of logged time - this could be tricky...
 - Last sync / next sync indicator
 - See if base workItem table would make things easier.
 - See if we can remove DevOpsId and insert id from DevOps into the Id column.
@@ -31,6 +28,9 @@ Estimatey hooks into the tools that you already use** and provides insights that
     - Warning when PR open for too long.
 
 ## Completed features
+- :white_check_mark: Write service to sync logged time from Float.
+    - :white_check_mark: Basic implementation fetch all every time.
+    - :white_check_mark: Persist historic data - after say a month we can assume that logged time won't change or maybe we can read the `locked` parameter.  We need to do this so we aren't fetching an every growing list of time logs and / or hit the 200 per page limit which means we would have to do paginated fetching. Will also need to support syncing historic data for a newly hooked up project with lots of logged time - this could be tricky...
 - :white_check_mark: Write service to sync work items from DevOps including features, user stories, tasks and their tags.
 - :white_check_mark: Write service to sync work item relationships from DevOps.
 - :white_check_mark: Make deleting more robust by storing last revised date and then only marking deleted if deleted date is after last revised date. NOTE: Turns out I don't think we need this as delete runs after update.  Lets see how we go and tweak if necessary.

--- a/estimatey-api/Estimatey.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/estimatey-api/Estimatey.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -17,5 +17,7 @@ public interface IApplicationDbContext
 
     DbSet<FloatPersonEntity> FloatPeople { get; }
 
+    DbSet<LoggedTimeEntity> LoggedTime { get;}
+
     Task<int> SaveChangesAsync(CancellationToken cancellationToken);
 }

--- a/estimatey-api/Estimatey.Application/Common/Interfaces/IDateTimeService.cs
+++ b/estimatey-api/Estimatey.Application/Common/Interfaces/IDateTimeService.cs
@@ -3,4 +3,6 @@ namespace Estimatey.Application.Common.Interfaces;
 public interface IDateTimeService
 {
     DateTime Now { get; }
+
+    DateOnly NowDateOnly { get; }
 }

--- a/estimatey-api/Estimatey.Application/Common/Models/LoggedTimeDto.cs
+++ b/estimatey-api/Estimatey.Application/Common/Models/LoggedTimeDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using Estimatey.Core.Entities;
+using System.Text.Json.Serialization;
 
 namespace Estimatey.Application.Common.Models;
 

--- a/estimatey-api/Estimatey.Application/DeveloperTime/Queries/ListLoggedTimeByDeveloper/ListLoggedTimeByDeveloperQuery.cs
+++ b/estimatey-api/Estimatey.Application/DeveloperTime/Queries/ListLoggedTimeByDeveloper/ListLoggedTimeByDeveloperQuery.cs
@@ -78,7 +78,7 @@ public class ListLoggedTimeByDeveloperQueryHandler : IRequestHandler<ListLoggedT
         var recentLoggedTime = await _floatClient.GetLoggedTime(
             project.FloatId,
             project.LoggedTimeHasBeenSyncedUntil?.AddDays(1),
-            DateOnly.FromDateTime(_dateTimeService.Now));
+            _dateTimeService.NowDateOnly);
 
         return recentLoggedTime
             .Where(loggedTime =>

--- a/estimatey-api/Estimatey.Infrastructure/DateTimes/DateTimeService.cs
+++ b/estimatey-api/Estimatey.Infrastructure/DateTimes/DateTimeService.cs
@@ -5,4 +5,6 @@ namespace Estimatey.Infrastructure.DateTimes;
 public class DateTimeService : IDateTimeService
 {
     public DateTime Now => DateTime.Now;
+
+    public DateOnly NowDateOnly => DateOnly.FromDateTime(DateTime.Now);
 }

--- a/estimatey-api/Estimatey.Infrastructure/Float/FloatHistoricLoggedTimeSyncer.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Float/FloatHistoricLoggedTimeSyncer.cs
@@ -33,10 +33,10 @@ public class FloatHistoricLoggedTimeSyncer
 
     public async Task SyncHistoricLoggedTime()
     {
+        await _floatClient.SyncPeople();
+
         var projects = await _dbContext.Projects.ToListAsync();
         var people = await _dbContext.FloatPeople.ToListAsync();
-
-        // TODO: sync float people like we do in ListDeveloperLoggedTimeQueryHandler.
 
         _logger.LogInformation("Syncing historic logged time for {projectsCount} projects.", projects.Count);
 

--- a/estimatey-api/Estimatey.Infrastructure/Float/FloatHistoricLoggedTimeSyncer.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Float/FloatHistoricLoggedTimeSyncer.cs
@@ -4,6 +4,7 @@ using Estimatey.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using System.Collections.Concurrent;
 
 namespace Estimatey.Infrastructure.Float;
 
@@ -15,6 +16,8 @@ public class FloatHistoricLoggedTimeSyncer
     private readonly IFloatClient _floatClient;
 
     private readonly int _persistLoggedTimeBeforeDaysAgo;
+
+    private static readonly ConcurrentDictionary<int, SemaphoreSlim> _semaphores = new();
 
     public FloatHistoricLoggedTimeSyncer(
         IOptions<FloatOptions> options,
@@ -48,40 +51,50 @@ public class FloatHistoricLoggedTimeSyncer
 
     private async Task SyncProject(ProjectEntity project, List<FloatPersonEntity> people)
     {
-        var syncLoggedTimeUntil = DateOnly.FromDateTime(_dateTimeService.Now.AddDays(-_persistLoggedTimeBeforeDaysAgo - 1));
+        var semaphore = _semaphores.GetOrAdd(project.Id, _ => new SemaphoreSlim(1, 1));
+        await semaphore.WaitAsync();
 
-        if (project.LoggedTimeHasBeenSyncedUntil is not null &&
-            project.LoggedTimeHasBeenSyncedUntil >= syncLoggedTimeUntil)
+        try
         {
-            _logger.LogInformation("Historic logged time is up to date so no need to sync.");
-            return;
+            var syncLoggedTimeUntil = DateOnly.FromDateTime(_dateTimeService.Now.AddDays(-_persistLoggedTimeBeforeDaysAgo - 1));
+
+            if (project.LoggedTimeHasBeenSyncedUntil is not null &&
+                project.LoggedTimeHasBeenSyncedUntil >= syncLoggedTimeUntil)
+            {
+                _logger.LogInformation("Historic logged time is up to date so no need to sync.");
+                return;
+            }
+
+            DateOnly? syncLoggedTimeFrom = project.LoggedTimeHasBeenSyncedUntil.HasValue ?
+                project.LoggedTimeHasBeenSyncedUntil.Value.AddDays(1) :
+                null;
+
+            _logger.LogDebug("Syncing historic logged time for project {projectId} between {startDate} and {endDate}.", project.Id, syncLoggedTimeFrom, syncLoggedTimeUntil);
+
+            var historicLoggedTime = await _floatClient.GetLoggedTime(project.FloatId, syncLoggedTimeFrom, syncLoggedTimeUntil);
+
+            var loggedTimeEntities = historicLoggedTime.Select(_ => new LoggedTimeEntity
+            {
+                FloatId = _.Id,
+                FloatPersonId = people.First(person => person.FloatId == _.PersonId).Id,
+                Date = DateOnly.Parse(_.Date),
+                Hours = _.Hours,
+                Locked = _.Locked,
+                LockedDate = _.LockedDate is null ? null : DateOnly.Parse(_.LockedDate),
+            });
+
+            _logger.LogDebug("Persisting {loggedTimeEntriesCount} logged time entries.", loggedTimeEntities.Count());
+
+            project.LoggedTimeHasBeenSyncedUntil = syncLoggedTimeUntil;
+
+            _dbContext.LoggedTime.AddRange(loggedTimeEntities);
+            await _dbContext.SaveChangesAsync();
+
+            _logger.LogDebug("Successfully synced historic logged time for project {projectId} between {startDate} and {endDate}.", project.Id, syncLoggedTimeFrom, syncLoggedTimeUntil);
         }
-
-        DateOnly? syncLoggedTimeFrom = project.LoggedTimeHasBeenSyncedUntil.HasValue ?
-            project.LoggedTimeHasBeenSyncedUntil.Value.AddDays(1) :
-            null;
-
-        _logger.LogDebug("Syncing historic logged time for project {projectId} between {startDate} and {endDate}.", project.Id, syncLoggedTimeFrom, syncLoggedTimeUntil);
-
-        var historicLoggedTime = await _floatClient.GetLoggedTime(project.FloatId, syncLoggedTimeFrom, syncLoggedTimeUntil);
-
-        var loggedTimeEntities = historicLoggedTime.Select(_ => new LoggedTimeEntity
+        finally
         {
-            FloatId = _.Id,
-            FloatPersonId = people.First(person => person.FloatId == _.PersonId).Id,
-            Date = DateOnly.Parse(_.Date),
-            Hours = _.Hours,
-            Locked = _.Locked,
-            LockedDate = _.LockedDate is null ? null : DateOnly.Parse(_.LockedDate),
-        });
-
-        _logger.LogDebug("Persisting {loggedTimeEntriesCount} logged time entries.", loggedTimeEntities.Count());
-
-        project.LoggedTimeHasBeenSyncedUntil = syncLoggedTimeUntil;
-
-        _dbContext.LoggedTime.AddRange(loggedTimeEntities);
-        await _dbContext.SaveChangesAsync();
-
-        _logger.LogDebug("Successfully synced historic logged time for project {projectId} between {startDate} and {endDate}.", project.Id, syncLoggedTimeFrom, syncLoggedTimeUntil);
+            semaphore.Release();
+        }
     }
 }

--- a/estimatey-api/Estimatey.Infrastructure/Float/FloatHistoricLoggedTimeSyncer.cs
+++ b/estimatey-api/Estimatey.Infrastructure/Float/FloatHistoricLoggedTimeSyncer.cs
@@ -56,7 +56,7 @@ public class FloatHistoricLoggedTimeSyncer
 
         try
         {
-            var syncLoggedTimeUntil = DateOnly.FromDateTime(_dateTimeService.Now.AddDays(-_persistLoggedTimeBeforeDaysAgo - 1));
+            var syncLoggedTimeUntil = _dateTimeService.NowDateOnly.AddDays(-_persistLoggedTimeBeforeDaysAgo - 1);
 
             if (project.LoggedTimeHasBeenSyncedUntil is not null &&
                 project.LoggedTimeHasBeenSyncedUntil >= syncLoggedTimeUntil)


### PR DESCRIPTION
- ensure people are synced before syncing logged time - old code would have crashed if a new person was added and had logged time.
- make DevOps and Float syncing methods threadsafe
- use the historic logged time cache in the list logged time endpoint so we only have to fetch recent work items on demand.